### PR TITLE
Implement `run` and `store` 

### DIFF
--- a/kotsu/run.py
+++ b/kotsu/run.py
@@ -1,0 +1,42 @@
+"""Interface for running a registry of models on a registry of validations."""
+from typing import Tuple
+
+import time
+
+from kotsu.registration import ModelRegistry, ValidationRegistry
+
+
+def run(
+    model_registry: ModelRegistry,
+    validation_registry: ValidationRegistry,
+    store_directory: str,
+    run_params: dict = {},
+):
+    """Run a registry of models on a registry of validations.
+
+    Args:
+        model_registry: A ModelRegistry containing the registry of models to be run through
+            validations.
+        validation_registry: A ValidationRegistry containing the registry of validations to run
+            each model through.
+        store_directory: A file path or URI location to store the validation results and any extra
+            output artefacts of the validations and models.
+        run_params: A dictionary of optional run parameters.
+    """
+    for validation_spec in validation_registry.all():
+        for model_spec in model_registry.all():
+            validation = validation_spec.make()
+            model = model_spec.make()
+            results, elapsed_secs = _run_validation_model(validation, model, run_params)
+
+
+def _run_validation_model(validation, model, run_params: dict = {}) -> Tuple[dict, float]:
+    """Run given validation on given model, and store the results.
+
+    Returns:
+        A tuple of (dict of results, elapsed time in seconds)
+    """
+    start_time = time.time()
+    results = validation(model)
+    elapsed_secs = time.time() - start_time
+    return results, elapsed_secs

--- a/kotsu/run.py
+++ b/kotsu/run.py
@@ -1,10 +1,14 @@
 """Interface for running a registry of models on a registry of validations."""
 from typing import Tuple
 
+import logging
 import time
 
 from kotsu import store
 from kotsu.registration import ModelRegistry, ValidationRegistry
+
+
+logger = logging.getLogger(__name__)
 
 
 def run(
@@ -27,6 +31,7 @@ def run(
     results_list = []
     for validation_spec in validation_registry.all():
         for model_spec in model_registry.all():
+            logger.info(f"Running validation - model: {validation_spec.id} - {model_spec.id}")
             validation = validation_spec.make()
             model = model_spec.make()
             results, elapsed_secs = _run_validation_model(validation, model, run_params)

--- a/kotsu/store.py
+++ b/kotsu/store.py
@@ -10,10 +10,7 @@ def write(results_list: List[dict], store_directory: str, to_front_cols: List[st
     """Write the results to the store directory."""
     df = pd.DataFrame(results_list)
 
-    cols = list(df)
-    for col in reversed(to_front_cols):
-        cols.insert(0, cols.pop(cols.index(col)))
-    df = df.loc[:, cols]
+    df = df[to_front_cols + [col for col in df.columns if col not in to_front_cols]]
 
     results_file_path = os.path.join(store_directory, "validation_results.csv")
     df.to_csv(results_file_path, index=False)

--- a/kotsu/store.py
+++ b/kotsu/store.py
@@ -1,0 +1,19 @@
+"""Functionality for storing validation results."""
+from typing import List
+
+import os.path
+
+import pandas as pd
+
+
+def write(results_list: List[dict], store_directory: str, to_front_cols: List[str]):
+    """Write the results to the store directory."""
+    df = pd.DataFrame(results_list)
+
+    cols = list(df)
+    for col in reversed(to_front_cols):
+        cols.insert(0, cols.pop(cols.index(col)))
+    df = df.loc[:, cols]
+
+    results_file_path = os.path.join(store_directory, "validation_results.csv")
+    df.to_csv(results_file_path, index=False)

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -8,3 +8,5 @@ pytest
 pytest-mock
 pytest-cov
 twine
+
+sklearn

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -48,6 +48,8 @@ jeepney==0.7.0
     # via
     #   keyring
     #   secretstorage
+joblib==1.0.1
+    # via scikit-learn
 keyring==23.0.1
     # via twine
 mccabe==0.6.1
@@ -58,10 +60,18 @@ mypy-extensions==0.4.3
     # via
     #   black
     #   mypy
+numpy==1.21.0
+    # via
+    #   -r requirements.txt
+    #   pandas
+    #   scikit-learn
+    #   scipy
 packaging==21.0
     # via
     #   bleach
     #   pytest
+pandas==1.3.0
+    # via -r requirements.txt
 pathspec==0.8.1
     # via black
 pkginfo==1.7.1
@@ -91,6 +101,14 @@ pytest-cov==2.12.1
     # via -r requirements.dev.in
 pytest-mock==3.6.1
     # via -r requirements.dev.in
+python-dateutil==2.8.2
+    # via
+    #   -r requirements.txt
+    #   pandas
+pytz==2021.1
+    # via
+    #   -r requirements.txt
+    #   pandas
 readme-renderer==29.0
     # via twine
 regex==2021.7.6
@@ -103,14 +121,24 @@ requests-toolbelt==0.9.1
     # via twine
 rfc3986==1.5.0
     # via twine
+scikit-learn==0.24.2
+    # via sklearn
+scipy==1.7.0
+    # via scikit-learn
 secretstorage==3.3.1
     # via keyring
 six==1.16.0
     # via
+    #   -r requirements.txt
     #   bleach
+    #   python-dateutil
     #   readme-renderer
+sklearn==0.0
+    # via -r requirements.dev.in
 snowballstemmer==2.1.0
     # via pydocstyle
+threadpoolctl==2.2.0
+    # via scikit-learn
 toml==0.10.2
     # via
     #   black

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,13 @@
 #
 #    pip-compile setup.py
 #
+numpy==1.21.0
+    # via pandas
+pandas==1.3.0
+    # via kotsu (setup.py)
+python-dateutil==2.8.2
+    # via pandas
+pytz==2021.1
+    # via pandas
+six==1.16.0
+    # via python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ REPO_ROOT = pathlib.Path(__file__).parent
 with open(REPO_ROOT / "README.md", encoding="utf-8") as f:
     README = f.read()
 
-REQUIREMENTS = []
+REQUIREMENTS = ["pandas"]
 
 setup(
     name="kotsu",

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -11,13 +11,13 @@ from kotsu.registration import ModelRegistry, ValidationRegistry
 model_registry = ModelRegistry()
 
 model_registry.register(
-    id="SCV-v1",
+    id="SVC-v1",
     entry_point=svm.SVC,
     kwargs={"kernel": "linear", "C": 1, "random_state": 1},
 )
 
 model_registry.register(
-    id="SCV-v2",
+    id="SVC-v2",
     entry_point=svm.SVC,
     kwargs={"kernel": "linear", "C": 0.5, "random_state": 1},
 )

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,57 @@
+"""An end to end example and test."""
+from typing import Callable
+
+from sklearn import datasets, svm
+from sklearn.model_selection import cross_val_score
+
+from kotsu import run
+from kotsu.registration import ModelRegistry, ValidationRegistry
+
+
+model_registry = ModelRegistry()
+
+model_registry.register(
+    id="SCV-v1",
+    entry_point=svm.SVC,
+    kwargs={"kernel": "linear", "C": 1, "random_state": 1},
+)
+
+model_registry.register(
+    id="SCV-v2",
+    entry_point=svm.SVC,
+    kwargs={"kernel": "linear", "C": 0.5, "random_state": 1},
+)
+
+validation_registry = ValidationRegistry()
+
+
+def factory_iris_cross_val(folds: int) -> Callable:
+    """Factory for iris cross validation."""
+
+    def iris_cross_val(model) -> dict:
+        """Iris classification cross validation."""
+        X, y = datasets.load_iris(return_X_y=True)
+        scores = cross_val_score(model, X, y, cv=folds)
+        results = {f"fold_{i}_score": score for i, score in enumerate(scores)}
+        results["mean_score"] = scores.mean()
+        results["std_score"] = scores.std()
+        return results
+
+    return iris_cross_val
+
+
+validation_registry.register(
+    id="iris_cross_val-v1",
+    entry_point=factory_iris_cross_val,
+    kwargs={"folds": 5},
+)
+
+validation_registry.register(
+    id="iris_cross_val-v2",
+    entry_point=factory_iris_cross_val,
+    kwargs={"folds": 10},
+)
+
+
+def test_run(tmpdir):
+    run.run(model_registry, validation_registry, tmpdir)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,50 @@
+from unittest import mock
+
+import kotsu
+
+
+class FakeRegistry:
+    def __init__(self, ids):
+        self.ids = ids
+
+    def all(self):
+        entitys = []
+        for id_ in self.ids:
+            entity = mock.Mock()
+            entity.id = id_
+            entitys.append(entity)
+        return entitys
+
+
+def test_run(mocker):
+    patched_run_validation_model = mocker.patch(
+        "kotsu.run._run_validation_model",
+        side_effect=[({"test_result": "result"}, 10), ({"test_result": "result"}, 10)],
+    )
+    patched_store_write = mocker.patch("kotsu.store.write")
+
+    store_directory = "test_dir"
+    models = ["model_1", "model_2"]
+    model_registry = FakeRegistry(models)
+    validations = ["validation_1"]
+    validation_registry = FakeRegistry(validations)
+
+    kotsu.run.run(model_registry, validation_registry, store_directory)
+
+    results = [
+        {
+            "test_result": "result",
+            "validation_id": "validation_1",
+            "model_id": "model_1",
+            "runtime_secs": 10,
+        },
+        {
+            "test_result": "result",
+            "validation_id": "validation_1",
+            "model_id": "model_2",
+            "runtime_secs": 10,
+        },
+    ]
+
+    assert patched_run_validation_model.call_count == 2
+    patched_store_write.assert_called_with(results, store_directory, to_front_cols=mock.ANY)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,26 @@
+import pandas as pd
+import pytest
+
+from kotsu import store
+
+
+@pytest.mark.parametrize(
+    "to_front_cols",
+    [
+        [],
+        ["result_b", "result_c"],
+    ],
+)
+def test_write(to_front_cols, tmpdir):
+    results = [
+        {"id": "v1", "result_b": 2, "result_c": 3},
+        {"id": "v2", "result_b": 20, "result_c": 30},
+    ]
+    store.write(results, tmpdir, to_front_cols)
+
+    df = pd.read_csv(tmpdir / "validation_results.csv")
+    assert len(df) == 2
+    assert len(df.columns) == 3
+    assert df.loc[0, "id"] == "v1"
+    if to_front_cols:
+        assert (df.columns[: len(to_front_cols)] == to_front_cols).all()


### PR DESCRIPTION
Includes:
- unit tests for both modules
- and end to end test for `kotsu` - likely I'll use this in the readme an explainer of what `kotsu` does and how to use it

Next steps could likely be/to be figured out:
- see about the passing through the artefact url to validation (and it passing to model) for storing artefacts
- see about adding tentaclio for URIs?