### PR TITLE
Implement functionality for passing an `artefacts_directory` to Validations

### DIFF
--- a/kotsu/typing.py
+++ b/kotsu/typing.py
@@ -19,3 +19,10 @@ Model = Any
 
 # A Validation is a callable (e.g. function) that takes a Model, and returns a Results.
 Validation = Callable[[Model], Results]
+
+# Validations can also take a Model _and_ an artefact directory, which is a string, which
+# Validations may use as the location to write any artefacts/data objects output by the Validation.
+# For storing Model artefacts (e.g. saving model state, or saving training history), Validations
+# should pass the `artefact_directory` to Models directly within the Validation, and Models should
+# be implemented such to use this arg as their output artefact store location.
+ValidationWithOutputArtefacts = Callable[[Model, str], Results]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,29 +1,38 @@
 from unittest import mock
 
+import pytest
+
 import kotsu
 
 
 class FakeRegistry:
     def __init__(self, ids):
         self.ids = ids
-
-    def all(self):
         entitys = []
-        for id_ in self.ids:
+        instances = []
+        for id_ in ids:
             entity = mock.Mock()
             entity.id = id_
             entitys.append(entity)
-        return entitys
+            instance = mock.Mock()
+            instance.return_value = {}
+            entity.make.return_value = instance
+            instances.append(instance)
+        self.entitys = entitys
+        self.instances = instances
+
+    def all(self):
+        return self.entitys
 
 
-def test_run(mocker):
+def test_form_results(mocker):
     patched_run_validation_model = mocker.patch(
         "kotsu.run._run_validation_model",
         side_effect=[({"test_result": "result"}, 10), ({"test_result": "result"}, 10)],
     )
     patched_store_write = mocker.patch("kotsu.store.write")
 
-    store_directory = "test_dir"
+    store_directory = "test_dir/"
     models = ["model_1", "model_2"]
     model_registry = FakeRegistry(models)
     validations = ["validation_1"]
@@ -48,3 +57,45 @@ def test_run(mocker):
 
     assert patched_run_validation_model.call_count == 2
     patched_store_write.assert_called_with(results, store_directory, to_front_cols=mock.ANY)
+
+
+@pytest.mark.parametrize("pass_artefacts_directory", [True, False])
+def test_validation_calls(pass_artefacts_directory, mocker):
+    _ = mocker.patch("kotsu.store.write")
+
+    store_directory = "test_dir/"
+    models = ["model_1", "model_2"]
+    model_registry = FakeRegistry(models)
+    validations = ["validation_1"]
+    validation_registry = FakeRegistry(validations)
+
+    kotsu.run.run(
+        model_registry,
+        validation_registry,
+        store_directory,
+        pass_artefacts_directory=pass_artefacts_directory,
+    )
+    if pass_artefacts_directory is True:
+        validation_registry.instances[0].assert_has_calls(
+            [
+                mock.call(
+                    model_registry.instances[0],
+                    artefacts_directory=f"{store_directory}validation_1/model_1/",
+                ),
+                mock.call(
+                    model_registry.instances[1],
+                    artefacts_directory=f"{store_directory}validation_1/model_2/",
+                ),
+            ]
+        )
+    else:
+        validation_registry.instances[0].assert_has_calls(
+            [
+                mock.call(
+                    model_registry.instances[0],
+                ),
+                mock.call(
+                    model_registry.instances[1],
+                ),
+            ]
+        )


### PR DESCRIPTION
- Add a new optional arg to `run`, which is a flag. 
- Form a unique URI location based on validation model, and pass this URI to the Validation, so that is can store its artefacts in that location (and it can pass the same location to any Models it instantiates if it wants). 
- Update `test_end_to_end` to demonstrate storing models that were trained during validation.