### PR TITLE
return list rather than dict_values from registry.all()

### DIFF
--- a/kotsu/registration.py
+++ b/kotsu/registration.py
@@ -116,6 +116,10 @@ class _Registry(Generic[Entity]):
     def all(self):
         """Return all the entitys in the registry."""
         return list(self.entity_specs.values())
+    
+    def get(self, id: str) -> _Spec[Any]:
+        """Return entity spec by id."""
+        return self.entity_specs[id]
 
     def register(
         self,


### PR DESCRIPTION
To support indexing and slicing