### PR TITLE
Implement `run` returning validation results df

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `run` now returns validation results dataframe
 ### Fixed
 - Added `typing_extensions` as a project dependency, where it wasn't specified before.
 

--- a/kotsu/run.py
+++ b/kotsu/run.py
@@ -24,7 +24,7 @@ def run(
     force_rerun: Optional[Union[Literal["all"], List[str]]] = None,
     artefacts_store_dir: Optional[str] = None,
     run_params: Optional[dict] = None,
-):
+) -> pd.DataFrame:
     """Run a registry of models through a registry of validations.
 
     Args:
@@ -45,6 +45,9 @@ def run(
             If not None, then validations will be passed two kwargs; `validation_artefacts_dir` and
             `model_artefacts_dir`.
         run_params: A dictionary of optional run parameters.
+
+    Returns:
+        pd.DataFrame: dataframe of validation results.
     """
     if run_params is None:
         run_params = {}
@@ -100,6 +103,7 @@ def run(
     store.write(
         results_df, results_path, to_front_cols=["validation_id", "model_id", "runtime_secs"]
     )
+    return results_df
 
 
 def _form_validation_partial_with_store_dirs(

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -44,7 +44,7 @@ def test_form_results(mocker, tmpdir):
     validation_registry = FakeRegistry(validations)
 
     results_path = str(tmpdir) + "validation_results.csv"
-    kotsu.run.run(model_registry, validation_registry, results_path=results_path)
+    out_df = kotsu.run.run(model_registry, validation_registry, results_path=results_path)
 
     results_df = pd.DataFrame(
         [
@@ -63,6 +63,7 @@ def test_form_results(mocker, tmpdir):
         ]
     )
 
+    pd.testing.assert_frame_equal(out_df, results_df)
     assert patched_run_validation_model.call_count == 2
     pd.testing.assert_frame_equal(
         patched_store_write.call_args[0][0],
@@ -152,13 +153,12 @@ def test_force_rerun(force_rerun, mocker, tmpdir):
     validation_registry = FakeRegistry(validations)
 
     results_path = str(tmpdir) + "validation_results.csv"
-    kotsu.run.run(
+    out_df = kotsu.run.run(
         model_registry,
         validation_registry,
         results_path=results_path,
         force_rerun=force_rerun,
     )
-    out_df = pd.read_csv(results_path)
 
     results_df = pd.DataFrame(
         [
@@ -180,13 +180,12 @@ def test_force_rerun(force_rerun, mocker, tmpdir):
     assert patched_run_validation_model.call_count == 2
     pd.testing.assert_frame_equal(out_df, results_df)
 
-    kotsu.run.run(
+    out_df = kotsu.run.run(
         model_registry,
         validation_registry,
         results_path=results_path,
         force_rerun=force_rerun,
     )
-    out_df = pd.read_csv(results_path)
 
     if force_rerun is None:
         assert patched_run_validation_model.call_count == 2


### PR DESCRIPTION
This doesn't feel super great to me, as I'd rather results were got one way instead there now being two, but I think it is worth it. 

Implements and closes #48 

- [x] Have you added to CHANGELOG.md for this PR?
