### PR TITLE
FIX: make module use module logger not root logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Made `registration` module use module logger and not root `logging` logger
+#### Development
+- Updated flake8 config for new version
 
 ## [v0.3.2] - 2022-09-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made `registration` module use module logger and not root `logging` logger
 #### Development
 - Updated flake8 config for new version
+- Updated scikit-learn package name
 
 ## [v0.3.2] - 2022-09-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Made `registration` module use module logger and not root `logging` logger
 
 ## [v0.3.2] - 2022-09-11
 ### Fixed

--- a/kotsu/registration.py
+++ b/kotsu/registration.py
@@ -113,7 +113,7 @@ class _Registry(Generic[Entity]):
 
     def make(self, id: str, **kwargs) -> Entity:
         """Instantiate an instance of an entity of the given ID."""
-        logging.info(f"Making new entity: {id} ({kwargs})")
+        logger.info(f"Making new entity: {id} ({kwargs})")
         try:
             return self.entity_specs[id].make(**kwargs)
         except KeyError:

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -8,4 +8,4 @@ pytest-mock
 pytest-cov
 twine
 
-sklearn
+scikit-learn

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ sections = TYPING, KOTSU_TYPING, STDLIB, THIRDPARTY, FIRSTPARTY, LOCALFOLDER
 exclude = .git,logs,.*/*.py,build/*.py,*.egg-info,versioneer.py,kotsu/_version.py
 max-line-length = 99
 max-complexity = 10
-ignore = W503, W391 #F405 - start with no ignored errors and add as required
+ignore = W503, W391
 # ref W503: see notes in https://lintlyci.github.io/Flake8Rules/rules/W503.html
 # ref W391: see pos issue with vim https://github.com/PyCQA/pycodestyle/issues/365
 


### PR DESCRIPTION
As per title.

Also seems like the `kwargs` aren't getting output in the log - no idea why :/ 

- [x] Have you added to CHANGELOG.md for this PR?
