### PR TITLE
Save results incrementally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped support for Python 3.7 and 3.8. Minimum required version is now Python 3.9.
 
 ### Changed
+- Results are now saved incrementally after each validation-model run completes, rather than
+  batching all results and saving at the end
 - Documented conda-forge release workflow and added conda-forge badges to README
 
 ### Fixed

--- a/kotsu/run.py
+++ b/kotsu/run.py
@@ -59,8 +59,6 @@ def run(
         results_df = pd.DataFrame(columns=["validation_id", "model_id", "runtime_secs"])
         results_df["runtime_secs"] = results_df["runtime_secs"].astype(int)
 
-    results_df = results_df.set_index(["validation_id", "model_id"], drop=False)
-
     for validation_spec in validation_registry.all():
         if validation_spec.deprecated:
             logger.info(f"Skipping validation: {validation_spec.id} - as is deprecated.")
@@ -70,10 +68,14 @@ def run(
                 logger.info(f"Skipping model: {model_spec.id} - as is deprecated.")
                 continue
 
+            # Skip if prior result exists for this validation-model combination, unless force-rerun
             if (
-                not force_rerun == "all"
+                (
+                    (results_df["validation_id"] == validation_spec.id)
+                    & (results_df["model_id"] == model_spec.id)
+                ).any()
+                and not force_rerun == "all"
                 and not (isinstance(force_rerun, list) and model_spec.id in force_rerun)
-                and (validation_spec.id, model_spec.id) in results_df.index
             ):
                 logger.info(
                     f"Skipping validation - model: {validation_spec.id} - {model_spec.id}"
@@ -109,11 +111,8 @@ def run(
                 results_path,
                 to_front_cols=["validation_id", "model_id", "runtime_secs"],
             )
-            # Re-index for skip checking on next iteration
-            results_df = results_df.set_index(["validation_id", "model_id"], drop=False)
 
-    # Return DataFrame with regular index
-    return results_df.reset_index(drop=True)
+    return results_df
 
 
 def _form_validation_partial_with_store_dirs(

--- a/kotsu/run.py
+++ b/kotsu/run.py
@@ -60,7 +60,6 @@ def run(
         results_df["runtime_secs"] = results_df["runtime_secs"].astype(int)
 
     results_df = results_df.set_index(["validation_id", "model_id"], drop=False)
-    results_list = []
 
     for validation_spec in validation_registry.all():
         if validation_spec.deprecated:
@@ -95,16 +94,26 @@ def run(
             model = model_spec.make()
             results, elapsed_secs = _run_validation_model(validation, model, run_params)
             results = _add_meta_data_to_results(results, elapsed_secs, validation_spec, model_spec)
-            results_list.append(results)
 
-    additional_results_df = pd.DataFrame.from_records(results_list)
-    results_df = pd.concat([results_df, additional_results_df], ignore_index=True)
-    results_df = results_df.drop_duplicates(subset=["validation_id", "model_id"], keep="last")
-    results_df = results_df.sort_values(by=["validation_id", "model_id"]).reset_index(drop=True)
-    store.write(
-        results_df, results_path, to_front_cols=["validation_id", "model_id", "runtime_secs"]
-    )
-    return results_df
+            # Save result immediately
+            new_row_df = pd.DataFrame.from_records([results])
+            results_df = pd.concat([results_df, new_row_df], ignore_index=True)
+            results_df = results_df.drop_duplicates(
+                subset=["validation_id", "model_id"], keep="last"
+            )
+            results_df = results_df.sort_values(by=["validation_id", "model_id"]).reset_index(
+                drop=True
+            )
+            store.write(
+                results_df,
+                results_path,
+                to_front_cols=["validation_id", "model_id", "runtime_secs"],
+            )
+            # Re-index for skip checking on next iteration
+            results_df = results_df.set_index(["validation_id", "model_id"], drop=False)
+
+    # Return DataFrame with regular index
+    return results_df.reset_index(drop=True)
 
 
 def _form_validation_partial_with_store_dirs(

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -255,3 +255,46 @@ def test_raise_if_valiation_returns_privilidged_key_name(result, mocker, tmpdir)
             validation_registry,
             results_path=results_path,
         )
+
+
+def test_incremental_save_on_exception(mocker, tmpdir):
+    """Test that results are saved incrementally even when a later model raises an exception."""
+    patched_run_validation_model = mocker.patch(
+        "kotsu.run._run_validation_model",
+        side_effect=[
+            ({"test_result": "result_1"}, 10),
+            ({"test_result": "result_2"}, 20),
+            Exception("Model 3 failed"),
+        ],
+    )
+    patched_store_write = mocker.patch("kotsu.store.write")
+
+    models = ["model_1", "model_2", "model_3"]
+    model_registry = FakeRegistry(models)
+    validations = ["validation_1"]
+    validation_registry = FakeRegistry(validations)
+
+    results_path = str(tmpdir) + "validation_results.csv"
+
+    # Run should raise exception from third model
+    with pytest.raises(Exception, match="Model 3 failed"):
+        kotsu.run.run(model_registry, validation_registry, results_path=results_path)
+
+    # Verify that first two models ran
+    assert patched_run_validation_model.call_count == 3
+
+    # Verify store.write was called twice (once for each successful model before exception)
+    assert patched_store_write.call_count == 2
+
+    # Verify first write had model_1 results
+    first_write_df = patched_store_write.call_args_list[0][0][0]
+    assert len(first_write_df) == 1
+    assert first_write_df.iloc[0]["model_id"] == "model_1"
+    assert first_write_df.iloc[0]["test_result"] == "result_1"
+
+    # Verify second write had both model_1 and model_2 results
+    second_write_df = patched_store_write.call_args_list[1][0][0]
+    assert len(second_write_df) == 2
+    assert second_write_df.iloc[0]["model_id"] == "model_1"
+    assert second_write_df.iloc[1]["model_id"] == "model_2"
+    assert second_write_df.iloc[1]["test_result"] == "result_2"


### PR DESCRIPTION
As per title. It's not efficient, but I think its fine given it's all small operations anyways. 

<details>
  <summary>Kept using pandas as: </summary>
  
  - Different validations CAN return different schemas:
    - 5-fold validation returns: fold_0_score, fold_1_score, ..., fold_4_score, mean_score, std_score
    - 10-fold validation returns: fold_0_score, ..., fold_9_score, mean_score, std_score
    - These have different numbers of columns
  - The current code handles this via pandas (kotsu/run.py:100-101):
  additional_results_df = pd.DataFrame.from_records(results_list)
  results_df = pd.concat([results_df, additional_results_df], ignore_index=True)
  - Pandas automatically handles the schema merging (fills missing columns with NaN).
  - There's no explicit schema management in the code - it relies on pandas' ability to auto-merge schemas.
  
  </details>

Closes #46 

- [x] Have you added to CHANGELOG.md for this PR?
